### PR TITLE
Fix: updateUser 해싱처리, getUser 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules
 # Keep environment variables out of version control
 .env
-test
+# __tests__/unit/controllers/users.controller.unit.spec.js
+# __tests__/unit/services/users.service.unit.spec.js
+.gitignore

--- a/src/controllers/users.controller.js
+++ b/src/controllers/users.controller.js
@@ -119,13 +119,6 @@ export class UserController {
       const userId = +req.userId;
       const { password, name, nickname, phone, address, role } = req.body;
 
-      //TODO 나중에 살리기 + 라우터에 미들웨어 추가
-      // if (req.userId !== userId) {
-      //   return res.status(403).json({
-      //     success: false,
-      //     message: '접근 권한이 없습니다.',
-      //   });
-      // }
       const data = {};
 
       if (password || name || nickname || phone || address || role) {

--- a/src/services/users.service.js
+++ b/src/services/users.service.js
@@ -144,13 +144,22 @@ export class UserService {
         };
       } else if (user.role === 'OWNER') {
         const store = await this.userRepository.getStoreByOwnerId(userId);
-        return {
-          nickname: user.nickname,
-          email: user.email,
-          profileImage: user.profileImage,
-          storeName: store.storeName,
-          createdAt: store.createdAt,
-        };
+        if (!store) {
+          return {
+            nickname: user.nickname,
+            email: user.email,
+            profileImage: user.profileImage,
+            storeName: 'store를 등록해주세요.',
+          };
+        } else {
+          return {
+            nickname: user.nickname,
+            email: user.email,
+            profileImage: user.profileImage,
+            storeName: store.storeName,
+            createdAt: store.createdAt,
+          };
+        }
       }
     } catch (err) {
       throw err;
@@ -180,6 +189,10 @@ export class UserService {
         } catch (err) {
           next(err);
         }
+      }
+
+      if (data.password) {
+        data.password = await bcrypt.hash(data.password, 10);
       }
 
       const updatedUser = await this.userRepository.updateUserByUserId(


### PR DESCRIPTION
>회원정보 수정시 password 해싱처리해서 변경 이후에도 로그인 가능하게 수정했고,

>회원정보 조회시 업장이 아직 등록되지 않은 OWNER도 정보를 볼수 있게 했습니다.